### PR TITLE
Improve CSV import

### DIFF
--- a/internal/import/bankinter.go
+++ b/internal/import/bankinter.go
@@ -1,8 +1,6 @@
 package importutil
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -26,24 +24,13 @@ var bankinterTransformers = []transformer{
 		v = strings.ReplaceAll(v, "\"", "")
 		v = strings.ReplaceAll(v, ",", "")
 
-		matches := re.FindStringSubmatch(v)
-		if len(matches) == 0 {
-			return fmt.Errorf("amount regex did not find any matches")
-		}
+		amount, err := parseAmount(v)
 
-		amount := matches[amountIndex]
-		decimal := matches[decimalIndex]
-
-		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
 		if err != nil {
 			return err
 		}
 
-		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
-			parsedAmount = parsedAmount * -1
-		}
-
-		entry.amount = parsedAmount
+		entry.amount = amount
 		return nil
 	},
 	func(_ string, entry *entry) error { // Saldo but we add the currency

--- a/internal/import/bankinter.go
+++ b/internal/import/bankinter.go
@@ -1,0 +1,55 @@
+package importutil
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var bankinterTransformers = []transformer{
+	func(v string, entry *entry) error { // Fecha Contable
+		t, err := time.Parse("02/01/2006", v)
+		if err != nil {
+			return err
+		}
+		entry.date = t
+		return nil
+	},
+	nil, // Fecha Valor
+	func(v string, entry *entry) error { // Descripcion
+		s := strings.ToLower(v)
+		entry.description = s
+		return nil
+	},
+	func(v string, entry *entry) error { // Importe
+		v = strings.ReplaceAll(v, "\"", "")
+		v = strings.ReplaceAll(v, ",", "")
+
+		matches := re.FindStringSubmatch(v)
+		if len(matches) == 0 {
+			return fmt.Errorf("amount regex did not find any matches")
+		}
+
+		amount := matches[amountIndex]
+		decimal := matches[decimalIndex]
+
+		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
+			parsedAmount = parsedAmount * -1
+		}
+
+		entry.amount = parsedAmount
+		return nil
+	},
+	func(_ string, entry *entry) error { // Saldo but we add the currency
+		entry.currency = "EUR"
+		return nil
+	},
+	nil,
+	nil,
+}

--- a/internal/import/evo.go
+++ b/internal/import/evo.go
@@ -1,0 +1,56 @@
+package importutil
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var cardPaymentString = regexp.MustCompile("pago en el dia tj-")
+
+var evoTransformers = []transformer{
+	func(v string, entry *entry) error {
+		t, err := time.Parse("02/01/2006", v)
+		if err != nil {
+			return err
+		}
+		entry.date = t
+		return nil
+	},
+	nil,
+	func(v string, entry *entry) error {
+		s := strings.ToLower(v)
+		result := cardPaymentString.ReplaceAllString(s, "")
+		entry.description = result
+		return nil
+	},
+	func(v string, entry *entry) error {
+		matches := re.FindStringSubmatch(v)
+		if len(matches) == 0 {
+			return fmt.Errorf("amount regex did not find any matches")
+		}
+
+		amount := matches[amountIndex]
+		decimal := matches[decimalIndex]
+
+		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
+			parsedAmount = parsedAmount * -1
+		}
+
+		entry.amount = parsedAmount
+		return nil
+	},
+	func(v string, entry *entry) error {
+		entry.currency = v
+		return nil
+	},
+	nil,
+	nil,
+}

--- a/internal/import/evo.go
+++ b/internal/import/evo.go
@@ -1,9 +1,7 @@
 package importutil
 
 import (
-	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -27,24 +25,13 @@ var evoTransformers = []transformer{
 		return nil
 	},
 	func(v string, entry *entry) error {
-		matches := re.FindStringSubmatch(v)
-		if len(matches) == 0 {
-			return fmt.Errorf("amount regex did not find any matches")
-		}
+		amount, err := parseAmount(v)
 
-		amount := matches[amountIndex]
-		decimal := matches[decimalIndex]
-
-		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
 		if err != nil {
 			return err
 		}
 
-		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
-			parsedAmount = parsedAmount * -1
-		}
-
-		entry.amount = parsedAmount
+		entry.amount = amount
 		return nil
 	},
 	func(v string, entry *entry) error {

--- a/internal/import/import_test.go
+++ b/internal/import/import_test.go
@@ -30,13 +30,14 @@ func TestImportCSV(t *testing.T) {
 	}
 	matcher := matcher.New(categories)
 
-	// Test CSV data
-	csvData := `Test Source,01/01/2024,Restaurant bill,-1234.56,USD
-Test Source,02/01/2024,Uber ride,-5000.00,USD
-Test Source,03/01/2024,Salary,500000.00,USD`
+	// Test CSV data - using evo format
+	csvData := `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
+01/01/2024,,Restaurant bill,-1234.56,USD,,5000.00
+02/01/2024,,Uber ride,-5000.00,USD,,0.00
+03/01/2024,,Salary,500000.00,USD,,500000.00`
 
 	reader := strings.NewReader(csvData)
-	info := Import(context.Background(), "test.csv", reader, s, matcher)
+	info := Import(context.Background(), "evo_test.csv", reader, s, matcher)
 	if info.Error != nil {
 		t.Errorf("Import failed with error: %v", info.Error)
 	}
@@ -52,8 +53,8 @@ Test Source,03/01/2024,Salary,500000.00,USD`
 	}
 
 	// Verify first expense
-	if expenses[0].Source() != "Test Source" {
-		t.Errorf("Expense[0].Source = %v, want Test Source", expenses[0].Source())
+	if expenses[0].Source() != "evo" {
+		t.Errorf("Expense[0].Source = %v, want evo", expenses[0].Source())
 	}
 	if expenses[0].Description() != "restaurant bill" {
 		t.Errorf("Expense[0].Description = %v, want restaurant bill", expenses[0].Description())
@@ -67,7 +68,7 @@ Test Source,03/01/2024,Salary,500000.00,USD`
 	if expenses[0].Currency() != "USD" {
 		t.Errorf("Expense[0].Currency = %v, want USD", expenses[0].Currency())
 	}
-	if expenses[0].CategoryID() == nil && *expenses[0].CategoryID() == 1 {
+	if expenses[0].CategoryID() == nil || *expenses[0].CategoryID() != 1 {
 		t.Errorf("Expense[0].CategoryID = %v, want 1", expenses[0].CategoryID())
 	}
 
@@ -78,7 +79,7 @@ Test Source,03/01/2024,Salary,500000.00,USD`
 	if expenses[1].Amount() != -500000 {
 		t.Errorf("Expense[1].Amount = %v, want -500000", expenses[1].Amount())
 	}
-	if expenses[1].CategoryID() == nil && *expenses[0].CategoryID() == 2 {
+	if expenses[1].CategoryID() == nil || *expenses[1].CategoryID() != 2 {
 		t.Errorf("Expense[1].CategoryID = %v, want 2", expenses[1].CategoryID())
 	}
 
@@ -222,11 +223,12 @@ func TestImportInvalidCSV(t *testing.T) {
 	}
 	matcher := matcher.New(categories)
 
-	// Test with invalid CSV data
-	csvData := `Test Source,invalid-date,Restaurant bill,-1234.56,USD`
+	// Test with invalid CSV data - using evo format with invalid date
+	csvData := `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
+invalid-date,,Restaurant bill,-1234.56,USD,,5000.00`
 
 	reader := strings.NewReader(csvData)
-	info := Import(context.Background(), "test.csv", reader, s, matcher)
+	info := Import(context.Background(), "evo_test.csv", reader, s, matcher)
 	if info.Error == nil {
 		t.Errorf("Expected 1 error")
 	}

--- a/internal/import/import_test.go
+++ b/internal/import/import_test.go
@@ -13,82 +13,166 @@ import (
 )
 
 func TestImportCSV(t *testing.T) {
-	logger := testutil.TestLogger(t)
-	s := testutil.SetupTestStorage(t, logger)
-
-	// Create test categories
-	categories := []storage.Category{
-		storage.NewCategory(1, "Food", "restaurant|food|grocery"),
-		storage.NewCategory(2, "Transport", "uber|taxi|transit"),
-	}
-
-	for _, c := range categories {
-		_, err := s.CreateCategory(context.Background(), c.Name(), c.Pattern())
-		if err != nil {
-			t.Fatalf("Failed to create category: %v", err)
-		}
-	}
-	matcher := matcher.New(categories)
-
-	// Test CSV data - using evo format
-	csvData := `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
+	tests := []struct {
+		name                 string
+		filename             string
+		csvData              string
+		expectedSource       string
+		expectedCurrency     string
+		expectedAmounts      []int64
+		expectedDescriptions []string
+	}{
+		{
+			name:     "Evo CSV format",
+			filename: "evo_test.csv",
+			csvData: `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
 01/01/2024,,Restaurant bill,-1234.56,USD,,5000.00
 02/01/2024,,Uber ride,-5000.00,USD,,0.00
-03/01/2024,,Salary,500000.00,USD,,500000.00`
-
-	reader := strings.NewReader(csvData)
-	info := Import(context.Background(), "evo_test.csv", reader, s, matcher)
-	if info.Error != nil {
-		t.Errorf("Import failed with error: %v", info.Error)
+03/01/2024,,Salary,500000.00,USD,,500000.00`,
+			expectedSource:       "evo",
+			expectedCurrency:     "USD",
+			expectedAmounts:      []int64{-123456, -500000, 50000000},
+			expectedDescriptions: []string{"restaurant bill", "uber ride", "salary"},
+		},
+		{
+			name:     "Bankinter CSV format",
+			filename: "bankinter_test.csv",
+			csvData: `Fecha Contable,Fecha Valor,Descripcion,Importe,Saldo,Columna6,Columna7
+01/01/2024,01/01/2024,Restaurant bill,"-1,234.56",5000.00,,
+02/01/2024,02/01/2024,Uber ride,"-5,000.00",0.00,,
+03/01/2024,03/01/2024,Salary,"500,000.00",500000.00,,`,
+			expectedSource:       "bankinter",
+			expectedCurrency:     "EUR",
+			expectedAmounts:      []int64{-123456, -500000, 50000000},
+			expectedDescriptions: []string{"restaurant bill", "uber ride", "salary"},
+		},
+		{
+			name:     "Revolut CSV format",
+			filename: "revolut_test.csv",
+			csvData: `Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance
+CHARGE,Current,2024-01-01 10:00:00,2024-01-01 10:01:00,Restaurant bill,1234.56,0.00,USD,COMPLETED,5000.00
+CHARGE,Current,2024-01-02 11:00:00,2024-01-02 11:01:00,Uber ride,5000.00,0.00,USD,COMPLETED,0.00
+INCOME,Current,2024-01-03 12:00:00,2024-01-03 12:01:00,Salary,500000.00,0.00,USD,COMPLETED,500000.00`,
+			expectedSource:       "revolut",
+			expectedCurrency:     "USD",
+			expectedAmounts:      []int64{-123456, -500000, 50000000},
+			expectedDescriptions: []string{"restaurant bill", "uber ride", "salary"},
+		},
+		{
+			name:     "Revolut CSV with fees",
+			filename: "revolut_fees.csv",
+			csvData: `Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance
+CHARGE,Current,2024-01-01 10:00:00,2024-01-01 10:01:00,Restaurant bill,1234.56,50.00,USD,COMPLETED,5000.00
+CHARGE,Current,2024-01-02 11:00:00,2024-01-02 11:01:00,Uber ride,5000.00,100.50,USD,COMPLETED,0.00
+INCOME,Current,2024-01-03 12:00:00,2024-01-03 12:01:00,Salary,500000.00,0.00,USD,COMPLETED,500000.00`,
+			expectedSource:       "revolut",
+			expectedCurrency:     "USD",
+			expectedAmounts:      []int64{-118456, -489950, 50000000},
+			expectedDescriptions: []string{"restaurant bill", "uber ride", "salary"},
+		},
+		{
+			name:     "Evo card payment string removal",
+			filename: "evo_special.csv",
+			csvData: `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
+01/01/2024,,Pago en el dia TJ-Amazon Purchase,-50.00,EUR,,5000.00`,
+			expectedSource:       "evo",
+			expectedCurrency:     "EUR",
+			expectedAmounts:      []int64{-5000},
+			expectedDescriptions: []string{"amazon purchase"},
+		},
+		{
+			name:     "Revolut single transaction with fee",
+			filename: "revolut_single_fee.csv",
+			csvData: `Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance
+CHARGE,Current,2024-01-01 10:00:00,2024-01-01 10:01:00,ATM Withdrawal,100.00,2.50,USD,COMPLETED,5000.00`,
+			expectedSource:   "revolut",
+			expectedCurrency: "USD",
+			expectedAmounts:  []int64{-9750},
+			expectedDescriptions: []string{
+				"atm withdrawal",
+			},
+		},
+		{
+			name:     "Bankinter large amount with commas",
+			filename: "bankinter_large.csv",
+			csvData: `Fecha Contable,Fecha Valor,Descripcion,Importe,Saldo,Columna6,Columna7
+01/01/2024,01/01/2024,Large Purchase,"-12,345.67",5000.00,,`,
+			expectedSource:       "bankinter",
+			expectedCurrency:     "EUR",
+			expectedAmounts:      []int64{-1234567},
+			expectedDescriptions: []string{"large purchase"},
+		},
 	}
 
-	// Verify imported expenses
-	expenses, err := s.GetAllExpenseTypes(context.Background())
-	if err != nil {
-		t.Fatalf("Failed to get expenses: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := testutil.TestLogger(t)
+			s := testutil.SetupTestStorage(t, logger)
 
-	if len(expenses) != 3 {
-		t.Fatalf("Expected 3 expenses, got %d", len(expenses))
-	}
+			// Create test categories
+			categories := []storage.Category{
+				storage.NewCategory(1, "Food", "restaurant|food|grocery"),
+				storage.NewCategory(2, "Transport", "uber|taxi|transit"),
+				storage.NewCategory(3, "Shopping", "amazon|purchase"),
+				storage.NewCategory(4, "Cash", "atm|withdrawal"),
+			}
 
-	// Verify first expense
-	if expenses[0].Source() != "evo" {
-		t.Errorf("Expense[0].Source = %v, want evo", expenses[0].Source())
-	}
-	if expenses[0].Description() != "restaurant bill" {
-		t.Errorf("Expense[0].Description = %v, want restaurant bill", expenses[0].Description())
-	}
-	if expenses[0].Amount() != -123456 {
-		t.Errorf("Expense[0].Amount = %v, want -123456", expenses[0].Amount())
-	}
-	if expenses[0].Type() != storage.ChargeType {
-		t.Errorf("Expense[0].Type = %v, want ChargeType", expenses[0].Type())
-	}
-	if expenses[0].Currency() != "USD" {
-		t.Errorf("Expense[0].Currency = %v, want USD", expenses[0].Currency())
-	}
-	if expenses[0].CategoryID() == nil || *expenses[0].CategoryID() != 1 {
-		t.Errorf("Expense[0].CategoryID = %v, want 1", expenses[0].CategoryID())
-	}
+			for _, c := range categories {
+				_, err := s.CreateCategory(context.Background(), c.Name(), c.Pattern())
+				if err != nil {
+					t.Fatalf("Failed to create category: %v", err)
+				}
+			}
+			matcher := matcher.New(categories)
 
-	// Verify second expense
-	if expenses[1].Description() != "uber ride" {
-		t.Errorf("Expense[1].Description = %v, want uber ride", expenses[1].Description())
-	}
-	if expenses[1].Amount() != -500000 {
-		t.Errorf("Expense[1].Amount = %v, want -500000", expenses[1].Amount())
-	}
-	if expenses[1].CategoryID() == nil || *expenses[1].CategoryID() != 2 {
-		t.Errorf("Expense[1].CategoryID = %v, want 2", expenses[1].CategoryID())
-	}
+			reader := strings.NewReader(tt.csvData)
+			info := Import(context.Background(), tt.filename, reader, s, matcher)
+			if info.Error != nil {
+				t.Errorf("Import failed with error: %v", info.Error)
+			}
 
-	// Verify third expense
-	if expenses[2].Amount() != 50000000 {
-		t.Errorf("Expense[2].Amount = %v, want 50000000", expenses[2].Amount())
-	}
-	if expenses[2].Type() != storage.IncomeType {
-		t.Errorf("Expense[2].Type = %v, want IncomeType", expenses[2].Type())
+			// Verify imported expenses
+			expenses, err := s.GetAllExpenseTypes(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to get expenses: %v", err)
+			}
+
+			expectedCount := len(tt.expectedAmounts)
+			if len(expenses) != expectedCount {
+				t.Fatalf("Expected %d expenses, got %d", expectedCount, len(expenses))
+			}
+
+			// Verify all expenses amounts, source, and currency
+			for i, expectedAmount := range tt.expectedAmounts {
+				if expenses[i].Source() != tt.expectedSource {
+					t.Errorf("Expense[%d].Source = %v, want %v", i, expenses[i].Source(), tt.expectedSource)
+				}
+				if expenses[i].Amount() != expectedAmount {
+					t.Errorf("Expense[%d].Amount = %v, want %v", i, expenses[i].Amount(), expectedAmount)
+				}
+				if expenses[i].Currency() != tt.expectedCurrency {
+					t.Errorf("Expense[%d].Currency = %v, want %v", i, expenses[i].Currency(), tt.expectedCurrency)
+				}
+
+				if expenses[i].Description() != tt.expectedDescriptions[i] {
+					t.Errorf(
+						"Expense[%d].Description = %v, want %v",
+						i,
+						expenses[i].Description(),
+						tt.expectedDescriptions[i],
+					)
+				}
+
+				// Verify expense type based on amount
+				expectedType := storage.ChargeType
+				if expectedAmount >= 0 {
+					expectedType = storage.IncomeType
+				}
+				if expenses[i].Type() != expectedType {
+					t.Errorf("Expense[%d].Type = %v, want %v", i, expenses[i].Type(), expectedType)
+				}
+			}
+		})
 	}
 }
 
@@ -168,7 +252,7 @@ func TestImportJSON(t *testing.T) {
 	if expenses[0].Currency() != "USD" {
 		t.Errorf("Expense[0].Currency = %v, want USD", expenses[0].Currency())
 	}
-	if expenses[0].CategoryID() == nil && *expenses[0].CategoryID() == 1 {
+	if expenses[0].CategoryID() == nil || *expenses[0].CategoryID() != 1 {
 		t.Errorf("Expense[0].CategoryID = %v, want 1", expenses[0].CategoryID())
 	}
 
@@ -179,7 +263,7 @@ func TestImportJSON(t *testing.T) {
 	if expenses[1].Amount() != -500000 {
 		t.Errorf("Expense[1].Amount = %v, want -500000", expenses[1].Amount())
 	}
-	if expenses[1].CategoryID() == nil && *expenses[0].CategoryID() == 2 {
+	if expenses[1].CategoryID() == nil || *expenses[1].CategoryID() != 2 {
 		t.Errorf("Expense[1].CategoryID = %v, want 2", expenses[1].CategoryID())
 	}
 
@@ -213,27 +297,52 @@ func TestImportInvalidFormat(t *testing.T) {
 }
 
 func TestImportInvalidCSV(t *testing.T) {
-	logger := testutil.TestLogger(t)
-	s := testutil.SetupTestStorage(t, logger)
-
-	// Create test categories
-	categories := []storage.Category{
-		storage.NewCategory(1, "Food", "restaurant|food|grocery"),
-		storage.NewCategory(2, "Transport", "uber|taxi|transit"),
+	tests := []struct {
+		name     string
+		filename string
+		csvData  string
+	}{
+		{
+			name:     "Evo CSV with invalid date",
+			filename: "evo_test.csv",
+			csvData: `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
+invalid-date,,Restaurant bill,-1234.56,USD,,5000.00`,
+		},
+		{
+			name:     "Bankinter CSV with invalid date",
+			filename: "bankinter_test.csv",
+			csvData: `Fecha Contable,Fecha Valor,Descripcion,Importe,Saldo,Columna6,Columna7
+invalid-date,01/01/2024,Restaurant bill,"-1,234.56",5000.00,,`,
+		},
+		{
+			name:     "Revolut CSV with invalid date",
+			filename: "revolut_test.csv",
+			csvData: `Type,Product,Started Date,Completed Date,Description,Amount,Fee,Currency,State,Balance
+CHARGE,Current,invalid-date,2024-01-01 10:01:00,Restaurant bill,1234.56,0.00,USD,COMPLETED,5000.00`,
+		},
 	}
-	matcher := matcher.New(categories)
 
-	// Test with invalid CSV data - using evo format with invalid date
-	csvData := `Fecha de la operación,Fecha Valor,Concepto,Importe,Divisa,Tipo de movimiento,Saldo disponible
-invalid-date,,Restaurant bill,-1234.56,USD,,5000.00`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := testutil.TestLogger(t)
+			s := testutil.SetupTestStorage(t, logger)
 
-	reader := strings.NewReader(csvData)
-	info := Import(context.Background(), "evo_test.csv", reader, s, matcher)
-	if info.Error == nil {
-		t.Errorf("Expected 1 error")
-	}
-	if !strings.Contains(info.Error.Error(), "parsing time") {
-		t.Errorf("Expected parsing error, got: %v", info.Error)
+			// Create test categories
+			categories := []storage.Category{
+				storage.NewCategory(1, "Food", "restaurant|food|grocery"),
+				storage.NewCategory(2, "Transport", "uber|taxi|transit"),
+			}
+			matcher := matcher.New(categories)
+
+			reader := strings.NewReader(tt.csvData)
+			info := Import(context.Background(), tt.filename, reader, s, matcher)
+			if info.Error == nil {
+				t.Errorf("Expected error")
+			}
+			if !strings.Contains(info.Error.Error(), "parsing time") {
+				t.Errorf("Expected parsing error, got: %v", info.Error)
+			}
+		})
 	}
 }
 

--- a/internal/import/revolut.go
+++ b/internal/import/revolut.go
@@ -1,8 +1,6 @@
 package importutil
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -30,56 +28,32 @@ var revolutTransformers = []transformer{
 		return nil
 	},
 	func(v string, entry *entry) error { // Amount
-		matches := re.FindStringSubmatch(v)
-		if len(matches) == 0 {
-			return fmt.Errorf("amount regex did not find any matches")
-		}
+		amount, err := parseAmount(v)
 
-		amount := matches[amountIndex]
-		decimal := matches[decimalIndex]
-
-		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
 		if err != nil {
 			return err
 		}
 
-		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
-			parsedAmount = parsedAmount * -1
-		}
-
-		if parsedAmount != 0 {
-			entry.amount = parsedAmount
-		}
+		entry.amount = amount
 
 		return nil
 	},
 	func(v string, entry *entry) error { // Fee
-		matches := re.FindStringSubmatch(v)
-		if len(matches) == 0 {
-			return fmt.Errorf("amount regex did not find any matches")
-		}
+		feeAmount, err := parseAmount(v)
 
-		amount := matches[amountIndex]
-		decimal := matches[decimalIndex]
-
-		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
 		if err != nil {
 			return err
 		}
 
-		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
-			parsedAmount = parsedAmount * -1
-		}
-
-		if parsedAmount != 0 {
+		if feeAmount != 0 {
 			if entry.amount != 0 {
-				entry.amount -= parsedAmount
+				entry.amount -= feeAmount
 			} else {
-				entry.amount = parsedAmount
+				entry.amount = feeAmount
 			}
 		}
 		if entry.charge {
-			entry.amount = entry.amount * -1
+			entry.amount *= -1
 		}
 		return nil
 	},

--- a/internal/import/revolut.go
+++ b/internal/import/revolut.go
@@ -1,0 +1,92 @@
+package importutil
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var revolutTransformers = []transformer{
+	func(v string, entry *entry) error {
+		if v == "CHARGE" {
+			entry.charge = true
+		}
+		return nil
+	}, // Type
+	nil, // Product
+	func(v string, entry *entry) error { // Started Date
+		t, err := time.Parse("2006-01-02 15:04:05", v)
+		if err != nil {
+			return err
+		}
+		entry.date = t
+		return nil
+	},
+	nil, // Completed Date
+	func(v string, entry *entry) error { // Description
+		s := strings.ToLower(v)
+		entry.description = s
+		return nil
+	},
+	func(v string, entry *entry) error { // Amount
+		matches := re.FindStringSubmatch(v)
+		if len(matches) == 0 {
+			return fmt.Errorf("amount regex did not find any matches")
+		}
+
+		amount := matches[amountIndex]
+		decimal := matches[decimalIndex]
+
+		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
+			parsedAmount = parsedAmount * -1
+		}
+
+		if parsedAmount != 0 {
+			entry.amount = parsedAmount
+		}
+
+		return nil
+	},
+	func(v string, entry *entry) error { // Fee
+		matches := re.FindStringSubmatch(v)
+		if len(matches) == 0 {
+			return fmt.Errorf("amount regex did not find any matches")
+		}
+
+		amount := matches[amountIndex]
+		decimal := matches[decimalIndex]
+
+		parsedAmount, err := strconv.ParseInt(fmt.Sprintf("%s%s", amount, decimal), 10, 64)
+		if err != nil {
+			return err
+		}
+
+		if strings.HasPrefix(v, "-") || strings.HasPrefix(v, "−") {
+			parsedAmount = parsedAmount * -1
+		}
+
+		if parsedAmount != 0 {
+			if entry.amount != 0 {
+				entry.amount -= parsedAmount
+			} else {
+				entry.amount = parsedAmount
+			}
+		}
+		if entry.charge {
+			entry.amount = entry.amount * -1
+		}
+		return nil
+	},
+	func(v string, entry *entry) error { // Currency
+		entry.currency = v
+		return nil
+	},
+	nil, // State
+	nil, // Balance
+}


### PR DESCRIPTION
Add custom CSV parsers for different bank providers. 
Extract bank provider from filename `<source>_*.csv`, and parse each column base on some simple heuristics 

Currently only supported providers I use. In the future we can explore ways to extend this using plugins or other tools 🔌 